### PR TITLE
Replace placeholder DOI with actual paper DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Computing](https://pubsonline.informs.org/journal/ijoc) under the [MIT License](
 
 The software and data in this repository are a snapshot of the software and data
 that were used in the research reported on in the paper 
-"py-irt: A Scalable Item Response Theory Library for Python" by J.P. Lalor and P. Rodriguez. 
+"[py-irt: A Scalable Item Response Theory Library for Python](https://doi.org/10.1287/ijoc.2022.1250)" by J.P. Lalor and P. Rodriguez. 
 The snapshot is based on 
 [this SHA](https://github.com/nd-ball/py-irt/commit/6c69584a42d34bd2b4fd1d43550ef7fbb92b755d) 
 in the development repository, which represents v0.4.5 of the package. 
@@ -19,7 +19,7 @@ get a more recent version or would like support**
 
 ## Cite
 
-To cite this software, please cite the [paper](https://doi.org/10.1287/ijoc.2019.0934) using its DOI and the software itself, using the following DOI.
+To cite this software, please cite the [paper](https://doi.org/10.1287/ijoc.2022.1250) using its DOI and the software itself, using the following DOI.
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6818509.svg)](https://doi.org/10.5281/zenodo.6818509)
 


### PR DESCRIPTION
It looks like the DOI for the paper is not active yet, so this might need to wait until that goes live.